### PR TITLE
update `no-redundant-clsx` to handle template literals

### DIFF
--- a/src/rules/no-redundant-clsx.ts
+++ b/src/rules/no-redundant-clsx.ts
@@ -34,11 +34,11 @@ const rule: Rule.RuleModule = {
 
                     const firstArg = clsxCallNode.arguments[0];
 
-                    if (firstArg?.type === 'Literal') {
+                    if (firstArg?.type === 'Literal' || firstArg?.type === 'TemplateLiteral') {
                         context.report({
                             messageId: 'default',
                             node: clsxCallNode,
-                            fix: (fixer) => fixer.replaceText(clsxCallNode, firstArg.raw!),
+                            fix: (fixer) => fixer.replaceText(clsxCallNode, sourceCode.getText(firstArg)),
                         });
                     }
 


### PR DESCRIPTION
This seemed to work for https://github.com/temoncher/eslint-plugin-clsx/issues/7 (I did a very basic test)