### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/no-redundant-clsx.ts
+++ b/src/rules/no-redundant-clsx.ts
@@ -16,6 +16,7 @@ export = createRule({
         schema: [
             {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     selector: { type: 'string' },
                 },

--- a/src/rules/prefer-logical-over-objects.ts
+++ b/src/rules/prefer-logical-over-objects.ts
@@ -15,6 +15,7 @@ export = createRule({
         schema: [
             {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     startingFrom: { type: 'number' },
                     endingWith: { type: 'number' },

--- a/src/rules/prefer-objects-over-logical.ts
+++ b/src/rules/prefer-objects-over-logical.ts
@@ -15,6 +15,7 @@ export = createRule({
         schema: [
             {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     startingFrom: { type: 'number' },
                     endingWith: { type: 'number' },


### PR DESCRIPTION
Some rules, for example [no-redundant-clsx](https://github.com/temoncher/eslint-plugin-clsx/blob/9d11dbc093055a04b12b6c9ab1ee15460b6606b4/src/rules/no-redundant-clsx.ts#L18) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.